### PR TITLE
Handle case in which filter function passed to bins filters everything

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,7 +57,12 @@ function compute(pixels, count, quality, filter) {
 
     //fix because quantize breaks on < 2
     var vboxes = quantize(pixelArray, Math.max(2,count)).vboxes
-    return vboxes.map(function(vb) { //map to array structure
-        return vb
-    }).slice(0, count)
+    if (vboxes) {
+        return vboxes.map(function(vb) { //map to array structure
+            return vb
+        }).slice(0, count)
+    }
+    else {
+        return [];
+    }
 }

--- a/test.js
+++ b/test.js
@@ -51,6 +51,20 @@ test("gets a palette of main colors from an array of pixels", function(t) {
     t.end()
 })
 
+test("gets bins from an empty array without crashing", function(t) {
+    //a red image
+    var red = array(100)
+        .map(function() { return RED })
+        .reduce(concat)
+
+    t.deepEqual(palette.bins(red, 1, 1, alwaysFalseFilter), [], 'should return empty array')
+    t.end()
+})
+
 function sum(prev, a) {
     return prev + a.amount
+}
+
+function alwaysFalseFilter(pixels, index) {
+    return false;
 }


### PR DESCRIPTION
Added a check to see if the `vboxes` that comes back from quantize exists before using it. It comes up if you pass a filter to `bins` that happens to filter out everything in an image and end up passing an empty `pixelArray` to quantize.